### PR TITLE
Add Dependabot config file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns: ["*"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Chart.lock
 deploy/charts/*/charts
+*.iml
+/.idea/

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- cm-maintainers
+reviewers:
+- cm-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+aliases:
+  cm-maintainers:
+    - munnerz
+    - joshvanl
+    - wallrj
+    - jakexks
+    - maelvls
+    - sgtcodfish
+    - inteon
+    - thatsmrtalbot
+    - erikgb


### PR DESCRIPTION
We have some random PRs from Dependabot, probably because of vulnerability alerts. This PR adds a simple Depedabot config, and also OWNERS files, so we can make Prow merge our PRs.

/cc @ThatsMrTalbot 