### PR TITLE
Ignore file making Renovate unhappy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cert-manager/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": [
+        "deploy/charts/example-approver-policy-plugin/values.yaml"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
I want to clean up the dependency dashboard, https://github.com/cert-manager/example-approver-policy-plugin/issues/25, and the Mend Developer portal for this project: https://developer.mend.io/github/cert-manager/example-approver-policy-plugin.

Nothing is interesting for Renovate to do in this file.